### PR TITLE
add nav link to blog content

### DIFF
--- a/client/components/navBar.jsx
+++ b/client/components/navBar.jsx
@@ -15,10 +15,10 @@ const NavBar = () => {
             <p>Web</p>
           </Link>
         </li>
-        <li className="hidden">
-          <Link to="theatrical">
-            <p>Theatrical</p>
-          </Link>
+        <li>
+          <a href="https://losgimenos.github.io/enzoThinks/" target="_blank">
+            <p>Blog</p>
+          </a>
         </li>
         </ul>
           <Link to="/">


### PR DESCRIPTION
Add Nav link to blog and blog content. 

Link as anchor until markup for in page content completed.