### PR TITLE
add broswersync for mobile testing. Adjust queries

### DIFF
--- a/dist/stylesheets/main.css
+++ b/dist/stylesheets/main.css
@@ -1,11 +1,3 @@
-.clearfix:after {
-   visibility: hidden;
-   display: block;
-   font-size: 0;
-   content: " ";
-   clear: both;
-   height: 0;
- }
 
 body {
   margin: 0;
@@ -13,15 +5,12 @@ body {
   background-color: black;
   box-sizing: border-box;
   overflow-x: hidden;
+  font-family: 'Raleway', sans-serif;
 }
 
 h2, h3 {
   color: #fff;
   text-decoration: underline;
-}
-
-div {
-  font-family: 'Raleway', sans-serif;
 }
 
 #header {
@@ -50,6 +39,7 @@ div {
 .nav-bar__title {
   position: relative;
   top: 0;
+  width: 75%;
 }
 
 .nav-bar__title h2 {
@@ -213,8 +203,13 @@ div.web-project-item-details {
 /*MEDIA QUERY TIME!!*/
 /************************/
 @media screen and (max-width: 980px) {
+
+  h1, h2, h3 {
+    font-family: sans-serif;
+  }
+
   #nav-bar {
-    width: 150%;
+    width: 131%;
     height: 4em;
     font-size: 200%;
   }
@@ -232,8 +227,8 @@ div.web-project-item-details {
   #header {
     margin: 0;
     padding: 0;
-    width: 150%;
-    height: 130vh;
+    width: 131%;
+    height: 100vh;
   }
 
   #hero-text {
@@ -252,8 +247,9 @@ div.web-project-item-details {
   }
 
   div.contact {
-    width: 150%;
+    width: 131%;
     font-size: 300%;
+    height: 100vh;
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "webpack-dev-server": "^1.16.2"
   },
   "devDependencies": {
+    "browser-sync": "^2.18.12",
+    "browser-sync-webpack-plugin": "^1.1.4",
     "eslint": "^3.9.1",
     "eslint-config-airbnb": "^13.0.0",
     "eslint-plugin-import": "^2.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const BrowserSyncPlugin = require('browser-sync-webpack-plugin');
 
 module.exports = {
   devtool: 'source-map',
@@ -24,4 +25,16 @@ module.exports = {
       },
     ],
   },
+  plugins: [
+    new BrowserSyncPlugin(
+      {
+        host: 'localhost',
+        port: 3000,
+        proxy: 'http://localhost:8080'
+      },
+      {
+        reload: false
+      }
+    )
+  ]
 };


### PR DESCRIPTION
Add BrowserSync to dev dependencies. 

Testing responsiveness in Browser makes me want to punch myself in the throat. Much better to see the quirks pull up on the devices themselves.

Queries adjusted to follow suit.